### PR TITLE
feat(client): add base client features for iframe event recording

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.7
         version: 2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.0
+        version: 1.2.0(@types/react@19.1.2)(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.4(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.1))
@@ -524,6 +527,24 @@ packages:
   '@pkgr/core@0.2.4':
     resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.0':
+    resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.40.0':
     resolution: {integrity: sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==}
@@ -2519,6 +2540,19 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@pkgr/core@0.2.4': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.2)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.2
+
+  '@radix-ui/react-slot@1.2.0(@types/react@19.1.2)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.2
 
   '@rollup/rollup-android-arm-eabi@4.40.0':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   projects/client:
     dependencies:
+      '@phosphor-icons/react':
+        specifier: ^2.1.7
+        version: 2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.4(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.1))
@@ -65,6 +68,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-router:
+        specifier: ^7.5.1
+        version: 7.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss:
         specifier: ^4.1.4
         version: 4.1.4
@@ -507,6 +513,13 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@phosphor-icons/react@2.1.7':
+    resolution: {integrity: sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@pkgr/core@0.2.4':
     resolution: {integrity: sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==}
@@ -972,6 +985,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cosmiconfig-typescript-loader@6.1.0:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
@@ -1750,6 +1767,16 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.5.1:
+    resolution: {integrity: sha512-/jjU3fcYNd2bwz9Q0xt5TwyiyoO8XjSEFXJY4O/lMAlkGTHWuHRAbR9Etik+lSDqMC7A7mz3UlXzgYT6Vl58sA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -1818,6 +1845,9 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1949,6 +1979,9 @@ packages:
     resolution: {integrity: sha512-bKBcbvuQHmsX116KcxHJuAcppiiBOfivOObh2O5aXNER6mce7YDDQJy00xQQNp1DhEfcSV2uOsvb3O3nN2cbcA==}
     cpu: [arm64]
     os: [linux]
+
+  turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   turbo-windows-64@2.5.0:
     resolution: {integrity: sha512-9BCo8oQ7BO7J0K913Czbc3tw8QwLqn2nTe4E47k6aVYkM12ASTScweXPTuaPFP5iYXAT6z5Dsniw704Ixa5eGg==}
@@ -2480,6 +2513,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@phosphor-icons/react@2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@pkgr/core@0.2.4': {}
 
   '@rollup/rollup-android-arm-eabi@4.40.0':
@@ -2944,6 +2982,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.0.2: {}
 
   cosmiconfig-typescript-loader@6.1.0(@types/node@22.14.1)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
@@ -3658,6 +3698,15 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router@7.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      cookie: 1.0.2
+      react: 19.1.0
+      set-cookie-parser: 2.7.1
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
   react@19.1.0: {}
 
   readdirp@3.6.0:
@@ -3750,6 +3799,8 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -3871,6 +3922,8 @@ snapshots:
 
   turbo-linux-arm64@2.5.0:
     optional: true
+
+  turbo-stream@2.4.0: {}
 
   turbo-windows-64@2.5.0:
     optional: true

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.7",
+    "@radix-ui/react-slot": "^1.2.0",
     "@tailwindcss/vite": "^4.1.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -11,9 +11,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.7",
     "@tailwindcss/vite": "^4.1.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router": "^7.5.1",
     "tailwindcss": "^4.1.4"
   },
   "devDependencies": {

--- a/projects/client/src/App.tsx
+++ b/projects/client/src/App.tsx
@@ -1,5 +1,0 @@
-function App() {
-  return <h1>Hello</h1>;
-}
-
-export default App;

--- a/projects/client/src/components/IconButton.tsx
+++ b/projects/client/src/components/IconButton.tsx
@@ -1,0 +1,18 @@
+import { Slot } from '@radix-ui/react-slot';
+import { ButtonHTMLAttributes } from 'react';
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: React.ReactNode;
+}
+
+export default function IconButton({ icon, ...rest }: IconButtonProps) {
+  return (
+    <button
+      className="p-4 bg-foreground rounded outline-none border-2 border-border hover:bg-hover active:bg-hover-1 ring-offset-2 ring-offset-background focus-visible:ring-2 focus-visible:ring-focus"
+      type="button"
+      {...rest}
+    >
+      <Slot className="text-text">{icon}</Slot>
+    </button>
+  );
+}

--- a/projects/client/src/components/LinkInput.tsx
+++ b/projects/client/src/components/LinkInput.tsx
@@ -1,0 +1,30 @@
+import { MagnifyingGlass } from '@phosphor-icons/react';
+import { useState } from 'react';
+
+interface LinkInputProps {
+  onSubmit(url: string): void;
+}
+
+export default function LinkInput({ onSubmit }: LinkInputProps) {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onSubmit(value);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="w-128">
+      <div className="flex items-center gap-3 h-12 py-4 px-3 rounded bg-foreground focus-within:ring-2 ring-focus">
+        <MagnifyingGlass size={24} className="text-slate-100" />
+        <input
+          type="text"
+          placeholder="http://localhost:5173/"
+          className="w-full outline-none text-text placeholder:text-placeholder"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </div>
+    </form>
+  );
+}

--- a/projects/client/src/components/PlayButton.tsx
+++ b/projects/client/src/components/PlayButton.tsx
@@ -1,0 +1,15 @@
+import { Pause, Play } from '@phosphor-icons/react';
+import IconButton from './IconButton';
+
+interface PlayButtonProps {
+  isPlaying: boolean;
+}
+
+export default function PlayButton({ isPlaying }: PlayButtonProps) {
+  return (
+    <IconButton
+      icon={isPlaying ? <Pause size={20} /> : <Play size={20} />}
+      aria-label={isPlaying ? 'Pause' : 'Play'}
+    />
+  );
+}

--- a/projects/client/src/components/PlayButton.tsx
+++ b/projects/client/src/components/PlayButton.tsx
@@ -1,15 +1,17 @@
 import { Pause, Play } from '@phosphor-icons/react';
+import { ButtonHTMLAttributes } from 'react';
 import IconButton from './IconButton';
 
-interface PlayButtonProps {
+interface PlayButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   isPlaying: boolean;
 }
 
-export default function PlayButton({ isPlaying }: PlayButtonProps) {
+export default function PlayButton({ isPlaying, ...rest }: PlayButtonProps) {
   return (
     <IconButton
       icon={isPlaying ? <Pause size={20} /> : <Play size={20} />}
       aria-label={isPlaying ? 'Pause' : 'Play'}
+      {...rest}
     />
   );
 }

--- a/projects/client/src/constants/acceptedEvents.ts
+++ b/projects/client/src/constants/acceptedEvents.ts
@@ -1,0 +1,1 @@
+export const ACCEPTED_EVENTS = ['click', 'mousemove', 'mouseenter', 'mouseout'];

--- a/projects/client/src/contexts/EventRecorderContext.tsx
+++ b/projects/client/src/contexts/EventRecorderContext.tsx
@@ -1,0 +1,15 @@
+import { createContext } from 'react';
+
+interface EventRecorderContextType {
+  isCapturing: boolean;
+  toggleCapturing: () => void;
+  clearCapturedEvents: () => void;
+  exportCapturedEvents: (url?: string) => void;
+  initializeEventCapture: (
+    iframeRef: React.RefObject<HTMLIFrameElement | null>,
+  ) => void;
+}
+
+export const EventRecorderContext = createContext<EventRecorderContextType>(
+  {} as EventRecorderContextType,
+);

--- a/projects/client/src/contexts/EventRecorderProvider.tsx
+++ b/projects/client/src/contexts/EventRecorderProvider.tsx
@@ -1,0 +1,121 @@
+import { ReactNode, useCallback, useRef, useState } from 'react';
+import { ACCEPTED_EVENTS } from '../constants/acceptedEvents';
+import { EventRecorderContext } from './EventRecorderContext';
+
+type CapturedEvent = {
+  type: string;
+  target: {
+    tag: string;
+    id: string;
+    class: string;
+    text: string | null;
+    style: string | null;
+  };
+  timestamp: number;
+  pageX: number | null;
+  pageY: number | null;
+};
+
+export function EventRecorderProvider({ children }: { children: ReactNode }) {
+  const [isCapturing, setIsCapturing] = useState(false);
+  const capturedEvents = useRef<Array<CapturedEvent>>([]);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const toggleCapturing = () => setIsCapturing((prev) => !prev);
+  const clearCapturedEvents = () => (capturedEvents.current = []);
+
+  const exportCapturedEvents = (url?: string) => {
+    if (!iframeRef || !iframeRef.current) return;
+
+    const iframeWindow = iframeRef.current.contentWindow;
+
+    const data = {
+      url,
+      events: capturedEvents.current,
+      viewport: {
+        width: iframeWindow!.innerWidth,
+        height: iframeWindow!.innerHeight,
+      },
+    };
+
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    });
+
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `eventos-${Date.now()}.json`;
+    a.click();
+  };
+
+  const logEvent = useCallback(
+    (e: Event) => {
+      if (!isCapturing || !ACCEPTED_EVENTS.includes(e.type)) return;
+
+      const target = e.target as HTMLElement;
+      if (target.nodeType !== 1) return;
+
+      const style = iframeRef.current?.contentWindow?.getComputedStyle(target);
+      const text = target.innerText?.slice(0, 100) || null;
+
+      capturedEvents.current.push({
+        type: e.type,
+        target: {
+          tag: target.tagName,
+          id: target.id,
+          class: target.className,
+          text,
+          style: style?.cursor ?? null,
+        },
+        timestamp: Date.now(),
+        pageX: (e as MouseEvent).pageX ?? null,
+        pageY: (e as MouseEvent).pageY ?? null,
+      });
+    },
+    [isCapturing],
+  );
+
+  const initializeEventCapture = useCallback(
+    (iframe: React.RefObject<HTMLIFrameElement | null>) => {
+      if (!iframe || !iframe.current) return;
+
+      iframeRef.current = iframe.current;
+
+      try {
+        const doc =
+          iframe.current.contentDocument ||
+          iframe.current.contentWindow?.document;
+        if (!doc) return;
+
+        const handler = (e: Event) => logEvent(e);
+
+        ACCEPTED_EVENTS.forEach((type) => {
+          doc.addEventListener(type, handler, true);
+        });
+
+        return () => {
+          ACCEPTED_EVENTS.forEach((type) => {
+            doc.removeEventListener(type, handler, true);
+          });
+        };
+      } catch (err) {
+        console.warn('Erro ao acessar o iframe:', err);
+      }
+    },
+    [logEvent],
+  );
+
+  return (
+    <EventRecorderContext.Provider
+      value={{
+        isCapturing,
+        toggleCapturing,
+        clearCapturedEvents,
+        exportCapturedEvents,
+        initializeEventCapture,
+      }}
+    >
+      {children}
+    </EventRecorderContext.Provider>
+  );
+}

--- a/projects/client/src/index.css
+++ b/projects/client/src/index.css
@@ -1,1 +1,18 @@
 @import "tailwindcss";
+
+@theme {
+  --color-background: #09090a;
+  --color-foreground: #18181b;
+  --color-text: #f9fafb;
+  --color-secondary-text: #a1a1aa;
+  --color-placeholder: #52525b;
+  --color-focus: #4f46e5;
+  --color-border: #27272a;
+  --color-border-1: #3f3f46;
+  --color-hover: #27272a;
+  --color-hover-1: #3f3f46;
+}
+
+body {
+  background-color: var(--color-background);
+}

--- a/projects/client/src/main.tsx
+++ b/projects/client/src/main.tsx
@@ -1,10 +1,18 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import './index.css';
+import Home from './pages/Home.tsx';
+import Recorder from './pages/Recorder.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/recorder/:url" element={<Recorder />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/projects/client/src/main.tsx
+++ b/projects/client/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import './index.css';
 import Home from './pages/Home.tsx';
 import Recorder from './pages/Recorder.tsx';
+import Test from './pages/Test.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -11,6 +12,11 @@ createRoot(document.getElementById('root')!).render(
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/recorder/:url" element={<Recorder />} />
+
+        {import.meta.env.MODE === 'development' && (
+          <Route path="/test" element={<Test />} />
+        )}
+
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/projects/client/src/main.tsx
+++ b/projects/client/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
+import { EventRecorderProvider } from './contexts/EventRecorderProvider.tsx';
 import './index.css';
 import Home from './pages/Home.tsx';
 import Recorder from './pages/Recorder.tsx';
@@ -11,7 +12,14 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/recorder/:url" element={<Recorder />} />
+        <Route
+          path="/recorder/:url"
+          element={
+            <EventRecorderProvider>
+              <Recorder />
+            </EventRecorderProvider>
+          }
+        />
 
         {import.meta.env.MODE === 'development' && (
           <Route path="/test" element={<Test />} />

--- a/projects/client/src/pages/Home.tsx
+++ b/projects/client/src/pages/Home.tsx
@@ -1,0 +1,19 @@
+import { useNavigate } from 'react-router';
+import LinkInput from '../components/LinkInput';
+
+export default function Home() {
+  const navigate = useNavigate();
+
+  function handleSubmit(url: string) {
+    navigate(`/recorder/${encodeURIComponent(url)}`);
+  }
+
+  return (
+    <div className="relative h-screen w-full flex justify-center items-center flex-col gap-4">
+      <h1 className="mb-6 text-2xl font-semibold text-text">
+        Insert a link to start recorder
+      </h1>
+      <LinkInput onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/projects/client/src/pages/Recorder.tsx
+++ b/projects/client/src/pages/Recorder.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router';
+
+export default function Recorder() {
+  const { url } = useParams();
+
+  return (
+    <>
+      <h1>Hello</h1>
+      <p>I'm watching {url}</p>
+    </>
+  );
+}

--- a/projects/client/src/pages/Recorder.tsx
+++ b/projects/client/src/pages/Recorder.tsx
@@ -1,12 +1,19 @@
+import { Broom, Export } from '@phosphor-icons/react';
 import { useParams } from 'react-router';
+import IconButton from '../components/IconButton';
+import PlayButton from '../components/PlayButton';
 
 export default function Recorder() {
   const { url } = useParams();
 
   return (
     <>
-      <h1>Hello</h1>
-      <p>I'm watching {url}</p>
+      <iframe className="h-screen w-full" src={url}></iframe>
+      <div className="flex gap-2 p-2 absolute bottom-4 right-4 bg-background rounded">
+        <PlayButton isPlaying={false} />
+        <IconButton icon={<Broom size={24} />} />
+        <IconButton icon={<Export size={24} />} />
+      </div>
     </>
   );
 }

--- a/projects/client/src/pages/Recorder.tsx
+++ b/projects/client/src/pages/Recorder.tsx
@@ -1,18 +1,129 @@
 import { Broom, Export } from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import IconButton from '../components/IconButton';
 import PlayButton from '../components/PlayButton';
 
+interface CapturedEvent {
+  type: string;
+  target: {
+    tag: string;
+    id: string;
+    class: string;
+    text: string | null;
+    style: string | null;
+  };
+  timestamp: number;
+  pageX: number | null;
+  pageY: number | null;
+}
+
+const acceptEvents = ['click', 'mousemove', 'mouseenter', 'mouseout'];
+
 export default function Recorder() {
   const { url } = useParams();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const capturedEvents = useRef<Array<CapturedEvent>>([]);
+  const [capturing, setCapturing] = useState<boolean>(false);
+
+  function toggleCapture() {
+    setCapturing((prevCapturing) => !prevCapturing);
+  }
+
+  function clearCapturedEvents() {
+    capturedEvents.current = [];
+  }
+
+  function exportCapturedEvents() {
+    if (!iframeRef || !iframeRef.current) return;
+
+    const iframeWindow = iframeRef.current.contentWindow;
+
+    const exportData = {
+      url: url,
+      events: capturedEvents.current,
+      viewport: {
+        width: iframeWindow!.innerWidth,
+        height: iframeWindow!.innerHeight,
+      },
+    };
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+      type: 'application/json',
+    });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `eventos-${Date.now()}.json`;
+    a.click();
+  }
+
+  const logEvent = useCallback(
+    (e: Event) => {
+      if (!capturing) return;
+      if (!acceptEvents.includes(e.type)) return;
+      if (!iframeRef || !iframeRef.current || !iframeRef.current.contentWindow)
+        return;
+
+      const target = e.target as HTMLElement;
+
+      if (target.nodeType !== 1) return;
+
+      const style = iframeRef.current.contentWindow.getComputedStyle(target);
+      const text = target.innerText?.slice(0, 100) || null;
+
+      const eventInfo = {
+        type: e.type,
+        target: {
+          tag: target.tagName,
+          id: target.id,
+          class: target.className,
+          text,
+          style: style?.cursor ?? null,
+        },
+        timestamp: Date.now(),
+        pageX: (e as MouseEvent).pageX ?? null,
+        pageY: (e as MouseEvent).pageY ?? null,
+      };
+
+      capturedEvents.current.push(eventInfo);
+    },
+    [capturing],
+  );
+
+  useEffect(() => {
+    if (!iframeRef || !iframeRef.current) return;
+
+    try {
+      const iframeWindow = iframeRef.current!.contentWindow;
+      const iframeDocument =
+        iframeRef.current!.contentDocument || iframeWindow!.document;
+
+      acceptEvents.forEach((type) => {
+        iframeDocument.addEventListener(type, logEvent, true);
+      });
+
+      return () => {
+        acceptEvents.forEach((type) => {
+          iframeDocument.removeEventListener(type, logEvent, true);
+        });
+      };
+    } catch (err) {
+      console.warn(
+        '❌ Não foi possível acessar o conteúdo do iframe. Verifique se a URL é do mesmo domínio.',
+        err,
+      );
+    }
+  }, [iframeRef, logEvent]);
 
   return (
     <>
-      <iframe className="h-screen w-full" src={url}></iframe>
+      <iframe ref={iframeRef} className="h-screen w-full" src={url} />
       <div className="flex gap-2 p-2 absolute bottom-4 right-4 bg-background rounded">
-        <PlayButton isPlaying={false} />
-        <IconButton icon={<Broom size={24} />} />
-        <IconButton icon={<Export size={24} />} />
+        <PlayButton onClick={toggleCapture} isPlaying={capturing} />
+        <IconButton onClick={clearCapturedEvents} icon={<Broom size={24} />} />
+        <IconButton
+          onClick={exportCapturedEvents}
+          icon={<Export size={24} />}
+        />
       </div>
     </>
   );

--- a/projects/client/src/pages/Recorder.tsx
+++ b/projects/client/src/pages/Recorder.tsx
@@ -1,127 +1,33 @@
 import { Broom, Export } from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { useParams } from 'react-router';
 import IconButton from '../components/IconButton';
 import PlayButton from '../components/PlayButton';
-
-interface CapturedEvent {
-  type: string;
-  target: {
-    tag: string;
-    id: string;
-    class: string;
-    text: string | null;
-    style: string | null;
-  };
-  timestamp: number;
-  pageX: number | null;
-  pageY: number | null;
-}
-
-const acceptEvents = ['click', 'mousemove', 'mouseenter', 'mouseout'];
+import { EventRecorderContext } from '../contexts/EventRecorderContext';
 
 export default function Recorder() {
   const { url } = useParams();
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const capturedEvents = useRef<Array<CapturedEvent>>([]);
-  const [capturing, setCapturing] = useState<boolean>(false);
-
-  function toggleCapture() {
-    setCapturing((prevCapturing) => !prevCapturing);
-  }
-
-  function clearCapturedEvents() {
-    capturedEvents.current = [];
-  }
-
-  function exportCapturedEvents() {
-    if (!iframeRef || !iframeRef.current) return;
-
-    const iframeWindow = iframeRef.current.contentWindow;
-
-    const exportData = {
-      url: url,
-      events: capturedEvents.current,
-      viewport: {
-        width: iframeWindow!.innerWidth,
-        height: iframeWindow!.innerHeight,
-      },
-    };
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: 'application/json',
-    });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `eventos-${Date.now()}.json`;
-    a.click();
-  }
-
-  const logEvent = useCallback(
-    (e: Event) => {
-      if (!capturing) return;
-      if (!acceptEvents.includes(e.type)) return;
-      if (!iframeRef || !iframeRef.current || !iframeRef.current.contentWindow)
-        return;
-
-      const target = e.target as HTMLElement;
-
-      if (target.nodeType !== 1) return;
-
-      const style = iframeRef.current.contentWindow.getComputedStyle(target);
-      const text = target.innerText?.slice(0, 100) || null;
-
-      const eventInfo = {
-        type: e.type,
-        target: {
-          tag: target.tagName,
-          id: target.id,
-          class: target.className,
-          text,
-          style: style?.cursor ?? null,
-        },
-        timestamp: Date.now(),
-        pageX: (e as MouseEvent).pageX ?? null,
-        pageY: (e as MouseEvent).pageY ?? null,
-      };
-
-      capturedEvents.current.push(eventInfo);
-    },
-    [capturing],
-  );
+  const {
+    isCapturing,
+    toggleCapturing,
+    clearCapturedEvents,
+    exportCapturedEvents,
+    initializeEventCapture,
+  } = useContext(EventRecorderContext);
 
   useEffect(() => {
-    if (!iframeRef || !iframeRef.current) return;
-
-    try {
-      const iframeWindow = iframeRef.current!.contentWindow;
-      const iframeDocument =
-        iframeRef.current!.contentDocument || iframeWindow!.document;
-
-      acceptEvents.forEach((type) => {
-        iframeDocument.addEventListener(type, logEvent, true);
-      });
-
-      return () => {
-        acceptEvents.forEach((type) => {
-          iframeDocument.removeEventListener(type, logEvent, true);
-        });
-      };
-    } catch (err) {
-      console.warn(
-        '❌ Não foi possível acessar o conteúdo do iframe. Verifique se a URL é do mesmo domínio.',
-        err,
-      );
-    }
-  }, [iframeRef, logEvent]);
+    return initializeEventCapture(iframeRef);
+  }, [initializeEventCapture, iframeRef]);
 
   return (
     <>
       <iframe ref={iframeRef} className="h-screen w-full" src={url} />
       <div className="flex gap-2 p-2 absolute bottom-4 right-4 bg-background rounded">
-        <PlayButton onClick={toggleCapture} isPlaying={capturing} />
+        <PlayButton onClick={toggleCapturing} isPlaying={isCapturing} />
         <IconButton onClick={clearCapturedEvents} icon={<Broom size={24} />} />
         <IconButton
-          onClick={exportCapturedEvents}
+          onClick={() => exportCapturedEvents(url)}
           icon={<Export size={24} />}
         />
       </div>

--- a/projects/client/src/pages/Test.tsx
+++ b/projects/client/src/pages/Test.tsx
@@ -1,0 +1,10 @@
+export default function Example() {
+  return (
+    <div className="relative h-screen w-full flex justify-center items-center flex-col gap-4">
+      <h1 className="mb-6 text-2xl font-semibold text-text">Test Page</h1>
+      <button className="text-text p-4 bg-foreground rounded hover:bg-hover active:bg-hover-1">
+        Test
+      </button>
+    </div>
+  );
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["MODE"],
   "tasks": {
     "transit": {
       "dependsOn": ["^transit"]


### PR DESCRIPTION
This pull request introduces the foundational client-side features for recording and exporting user interactions within an iframe. It also includes development tooling and structural improvements to support future enhancements.

## Features

### Recorder Page
   - Iframe embed for dynamic URLs
   - UI controls for play/pause, clear and export
 
### Event Capturing
- Captures click, mousemove, mouseenter, and mouseout events
- Extracts target element metadata (tag, ID, class, inner text, cursor)

### Exporting
- Downloads captured events as a .json file
- Includes viewport info and event timestamp

### Development Enhancements
- Dev-only route for accessing the recorder
- Basic navigation and URL input