### PR TITLE
feat(cli): add initial CLI to start the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "prepare": "husky",
     "precommit": "turbo run precommit",
     "dev": "turbo run dev --parallel",
+    "dev:cli": "turbo run dev --filter=@event-recorder/cli",
     "dev:server": "turbo run dev --filter=@event-recorder/server",
     "dev:client": "turbo run dev --filter=@event-recorder/client",
     "build": "turbo run build",
+    "build:cli": "turbo run build --filter=@event-recorder/cli",
     "build:server": "turbo run build --filter=@event-recorder/server",
     "build:static": "turbo run build --filter=@event-recorder/static",
     "build:client": "turbo run build --filter=@event-recorder/client",
@@ -30,5 +32,8 @@
     "tsup": "^8.4.0",
     "turbo": "^2.5.0"
   },
-  "packageManager": "pnpm@10.9.0"
+  "packageManager": "pnpm@10.9.0",
+  "dependencies": {
+    "@event-recorder/cli": "link:projects/cli"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@event-recorder/cli': link:projects/cli
+
 importers:
 
   .:
+    dependencies:
+      '@event-recorder/cli':
+        specifier: link:projects/cli
+        version: link:projects/cli
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.3.0
@@ -56,6 +63,34 @@ importers:
       typescript-eslint:
         specifier: ^8.26.1
         version: 8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.7.3)
+
+  projects/cli:
+    dependencies:
+      '@commander-js/extra-typings':
+        specifier: ^13.1.0
+        version: 13.1.0(commander@13.1.0)
+      '@event-recorder/server':
+        specifier: workspace:^
+        version: link:../server
+      chalk:
+        specifier: ^4
+        version: 4.1.2
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+    devDependencies:
+      '@event-recorder/eslint-config':
+        specifier: workspace:^
+        version: link:../../packages/eslint-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      eslint:
+        specifier: ^9.22.0
+        version: 9.25.0(jiti@2.4.2)
+      typescript:
+        specifier: ~5.7.2
+        version: 5.7.3
 
   projects/client:
     dependencies:
@@ -245,6 +280,11 @@ packages:
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
+
+  '@commander-js/extra-typings@13.1.0':
+    resolution: {integrity: sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==}
+    peerDependencies:
+      commander: ~13.1.0
 
   '@commitlint/cli@19.8.0':
     resolution: {integrity: sha512-t/fCrLVu+Ru01h0DtlgHZXbHV2Y8gKocTR5elDOqIRUzQd0/6hpt2VIWOj9b3NDo7y4/gfxeR2zRtXq/qO6iUg==}
@@ -1109,6 +1149,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3031,6 +3075,10 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@commander-js/extra-typings@13.1.0(commander@13.1.0)':
+    dependencies:
+      commander: 13.1.0
+
   '@commitlint/cli@19.8.0(@types/node@22.15.3)(typescript@5.7.3)':
     dependencies:
       '@commitlint/format': 19.8.0
@@ -3884,6 +3932,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@13.1.0: {}
 
   commander@4.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.1
+      '@types/express-serve-static-core':
+        specifier: ^5.0.6
+        version: 5.0.6
       eslint:
         specifier: ^9.22.0
         version: 9.25.0(jiti@2.4.2)
@@ -815,9 +818,6 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/node@22.14.1':
-    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
@@ -3483,21 +3483,21 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.14.1
+      '@types/node': 22.15.3
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.3
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.3
 
   '@types/estree@1.0.7': {}
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 22.15.3
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -3513,10 +3513,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/mime@1.3.5': {}
-
-  '@types/node@22.14.1':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.15.3':
     dependencies:
@@ -3537,12 +3533,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.14.1
+      '@types/node': 22.15.3
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.14.1
+      '@types/node': 22.15.3
       '@types/send': 0.17.4
 
   '@typescript-eslint/eslint-plugin@8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.25.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.25.0(jiti@2.4.2))(typescript@5.7.3)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
-  - "projects/*"
-  - "packages/*"
+  - projects/*
+  - packages/*
+
+overrides:
+  '@event-recorder/cli': link:projects/cli

--- a/projects/cli/.gitignore
+++ b/projects/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/projects/cli/eslint.config.mjs
+++ b/projects/cli/eslint.config.mjs
@@ -1,0 +1,3 @@
+import eslintNode from '@event-recorder/eslint-config/node.js';
+
+export default [...eslintNode, { ignores: ['public'] }];

--- a/projects/cli/package.json
+++ b/projects/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@event-recorder/cli",
+  "version": "0.0.1",
+  "bin": {
+    "evtrec": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "start": "node ./dist/",
+    "dev": "tsx watch ./src/index.ts",
+    "build": "tsup",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit -p ."
+  },
+  "dependencies": {
+    "@commander-js/extra-typings": "^13.1.0",
+    "@event-recorder/server": "workspace:^",
+    "chalk": "^4",
+    "commander": "^13.1.0"
+  },
+  "devDependencies": {
+    "@event-recorder/eslint-config": "workspace:^",
+    "@types/node": "^22.15.3",
+    "eslint": "^9.22.0",
+    "typescript": "~5.7.2"
+  },
+  "bundleDependencies": [
+    "@event-recorder/server"
+  ]
+}

--- a/projects/cli/src/index.ts
+++ b/projects/cli/src/index.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { program } from '@commander-js/extra-typings';
+import { Server } from '@event-recorder/server';
+import chalk from 'chalk';
+import packageJSON from '../package.json';
+
+program.version(packageJSON.version);
+
+program
+  .description('Starts the server and logs browser events')
+  .option(
+    '-p, --port <port>',
+    'Specifies the server port (default: 3001)',
+    '3001',
+  )
+  .action((cmd) => {
+    const port = Number(cmd.port);
+    if (isNaN(port) || port < 1 || port > 65535) {
+      console.log(
+        chalk.red('Error: Port must be a valid number between 1 and 65535.'),
+      );
+      process.exit(1);
+    }
+
+    const server = new Server({ port });
+    server.start();
+  });
+
+program.parse(process.argv);

--- a/projects/cli/tsconfig.json
+++ b/projects/cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "NodeNext",
+    "moduleDetection": "force",
+    "moduleResolution": "nodenext",
+    "baseUrl": "src",
+    "rootDirs": ["src"],
+    "outDir": "dist",
+    "paths": {
+      "@/*": ["*"],
+    },
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": []
+}

--- a/projects/cli/tsup.config.ts
+++ b/projects/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  tsconfig: 'tsconfig.json',
+  treeshake: true,
+  minify: true,
+  shims: true,
+  dts: true,
+});

--- a/projects/server/package.json
+++ b/projects/server/package.json
@@ -1,9 +1,22 @@
 {
   "name": "@event-recorder/server",
+  "private": true,
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.mjs",
+      "require": "./dist/server.js",
+      "default": "./dist/server.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!dist/index*"
+  ],
   "scripts": {
     "start": "node ./dist/",
     "dev": "tsx watch ./src/index.ts",
-    "build": "tsc && tsc-alias",
+    "build": "tsup --format cjs,esm",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit -p ."
@@ -15,10 +28,13 @@
   "devDependencies": {
     "@event-recorder/eslint-config": "workspace:^",
     "@types/express": "^5.0.1",
+    "@types/express-serve-static-core": "^5.0.6",
     "eslint": "^9.22.0",
     "tsc-alias": "^1.8.15",
     "tsx": "^4.19.3",
     "typescript": "~5.7.2"
   },
-  "bundleDependencies": ["@event-recorder/static"]
+  "bundleDependencies": [
+    "@event-recorder/static"
+  ]
 }

--- a/projects/server/src/server.ts
+++ b/projects/server/src/server.ts
@@ -1,0 +1,1 @@
+export { default as Server } from '@/core/server/Server';

--- a/projects/server/tsup.config.ts
+++ b/projects/server/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/server.ts'],
+  clean: true,
+  tsconfig: 'tsconfig.json',
+  treeshake: true,
+  minify: true,
+  shims: true,
+  dts: true,
+});


### PR DESCRIPTION
This pull request introduces a basic command-line interface (CLI) to start the server directly from the terminal, allowing developers to specify a port and quickly launch the event recording backend.

# Features

## CLI Initialization
- Adds a new CLI entry point using `commander`
- Implements the `--port` option to customize the server port (default: 3001)
- Validates port input to ensure it’s within a valid range (1–65535)

## Server Integration
- Starts the `@event-recorder/server` using the  `Server` class